### PR TITLE
Ignoring comments in topology files now

### DIFF
--- a/garnish/parse.py
+++ b/garnish/parse.py
@@ -43,6 +43,8 @@ def parse_top(top_file):
     # read the file as lines and parse data
     with open(top_file, 'r') as f:
         for line in f.readlines():
+            if line.startswith(";"):
+                continue # Ignore comments
             # look for included topologies
             if match := regexp_include.match(line):
                 include_file = match.group(1)

--- a/garnish/system.py
+++ b/garnish/system.py
@@ -49,11 +49,16 @@ class System:
         for block_id, block in self.sys_dict['blocks'].items():
             moltype = block['moltype']
             n_mol = block['n_molecules']
+            try:
+                n_at = self.sys_dict['topology'][moltype]['n_atoms']
+                a_types = self.sys_dict['topology'][moltype]['atomtypes']
 
-            n_at = self.sys_dict['topology'][moltype]['n_atoms']
-            a_types = self.sys_dict['topology'][moltype]['atomtypes']
-
-            connectivity = self.sys_dict['topology'][moltype]['connectivity']
+                connectivity = self.sys_dict['topology'][moltype]['connectivity']
+            except KeyError:
+                # This fails when the molecule is not in the topology
+                # Instead of just breaking, i think it's better to continue but warn about it
+                print(f"Warning: Molecule {moltype} is in the structure, but not in the topology. Skipping...")
+                continue
             # transform bonds in numpy arrays to easily apply offset
             connectivity = {btype: np.array(bonds) for btype, bonds in connectivity.items()}
 


### PR DESCRIPTION
#45 
I added a check to see if a line starts with a comment, if it does the loop just continues.
Also while doing this i added a try except block to catch missing molecules and warn about them instead of just breaking the script.